### PR TITLE
Field invoked, but object selected

### DIFF
--- a/godefinfo.go
+++ b/godefinfo.go
@@ -210,6 +210,20 @@ repeat:
 	if obj == nil {
 		log.Fatalf("no type information for identifier %q at %d", identX.Name, *offset)
 	}
+
+	if obj, ok := obj.(*types.Var); ok && obj.IsField() {
+		// Struct literal
+		if lit, ok := nodes[2].(*ast.CompositeLit); ok {
+			if parent, ok := lit.Type.(*ast.SelectorExpr); ok {
+				fmt.Println(obj.Pkg().Path(), parent.Sel, obj.Id())
+				return
+			} else if parent, ok := lit.Type.(*ast.Ident); ok {
+				fmt.Println(obj.Pkg().Path(), parent, obj.Id())
+				return
+			}
+		}
+	}
+
 	if pkgName, ok := obj.(*types.PkgName); ok {
 		fmt.Println(pkgName.Imported().Path())
 	} else if selX == nil {

--- a/godefinfo.go
+++ b/godefinfo.go
@@ -240,8 +240,7 @@ repeat:
 				fmt.Println(pkg, name)
 				return
 			}
-			log.Fatalf("not a package-level definition (ident: %v, object: %v) and unable to follow type (type: %v)", identX, obj, t)
-			return
+			log.Fatal("method or field not found")
 		}
 
 		fmt.Println(objectString(recv.Obj()), identX.Name)

--- a/godefinfo.go
+++ b/godefinfo.go
@@ -232,9 +232,16 @@ repeat:
 			log.Fatal("receiver is not a top-level named type")
 		}
 
-		obj, _, _ := types.LookupFieldOrMethod(sel.Recv(), true, pkg, identX.Name)
-		if obj == nil {
-			log.Fatal("method or field not found")
+		field, _, _ := types.LookupFieldOrMethod(sel.Recv(), true, pkg, identX.Name)
+		if field == nil {
+			// field invoked, but object is selected
+			t := dereferenceType(obj.Type())
+			if pkg, name, ok := typeName(t); ok {
+				fmt.Println(pkg, name)
+				return
+			}
+			log.Fatalf("not a package-level definition (ident: %v, object: %v) and unable to follow type (type: %v)", identX, obj, t)
+			return
 		}
 
 		fmt.Println(objectString(recv.Obj()), identX.Name)

--- a/godefinfo_test.go
+++ b/godefinfo_test.go
@@ -100,7 +100,7 @@ func init() {
 
 	z := T{} //z: p T
 	z // p T
-    z.M0 //z: p T
+	z.M0 //z: p T
 }
 
 func F() {} //F: p F

--- a/godefinfo_test.go
+++ b/godefinfo_test.go
@@ -101,6 +101,7 @@ func init() {
 	z := T{} //z: p T
 	z // p T
 	z.M0 //z: p T
+	T{F0: 1} //F0: p T F0
 }
 
 func F() {} //F: p F

--- a/godefinfo_test.go
+++ b/godefinfo_test.go
@@ -100,6 +100,7 @@ func init() {
 
 	z := T{} //z: p T
 	z // p T
+    z.M0 //z: p T
 }
 
 func F() {} //F: p F

--- a/testdata/src/mypkg/a.go
+++ b/testdata/src/mypkg/a.go
@@ -20,6 +20,8 @@ func init() {
 	subpkg.C0        // mypkg/subpkg C0
 	(subpkg.C1{}).C2 // mypkg/subpkg C1 C2
 	strings.Contains // strings Contains
+
+	subpkg.C3{C4: subpkg.C1} //C4: mypkg/subpkg C3 C4
 }
 
 func A0() {}

--- a/testdata/src/mypkg/subpkg/c.go
+++ b/testdata/src/mypkg/subpkg/c.go
@@ -5,3 +5,7 @@ func C0() {}
 type C1 struct{}
 
 func (C1) C2() {}
+
+type C3 struct {
+	C4 C1
+}


### PR DESCRIPTION
This PR fixes the case where a user would select an object with a field invoked on it, and get the error "method or field not found", when they should find the type of the selected object.
